### PR TITLE
Add `&sparse=0` to the gitlab repository URL

### DIFF
--- a/helmfiles/subhelmfiles/gitlab.helmfile.yaml
+++ b/helmfiles/subhelmfiles/gitlab.helmfile.yaml
@@ -11,7 +11,7 @@
 
 repositories:
   - name: "gitlab"
-    url: "git+https://gitlab.com/gitlab-org/charts/gitlab@/?ref=d70eee5f2cf5449289862f4785c25f958aa07813" # Chart version 4.3.6
+    url: "git+https://gitlab.com/gitlab-org/charts/gitlab@/?ref=d70eee5f2cf5449289862f4785c25f958aa07813&sparse=0" # Chart version 4.3.6
 
 missingFileHandler: Error
 


### PR DESCRIPTION
## what
- Add `&sparse=0` to the gitlab helm repo URL due to this issue that was discovered:

## why
- See image. On @Colton-Wrisner's machine it doesn't work without `&sparse=0` added.
![image (5)](https://user-images.githubusercontent.com/16000938/97228019-b3020580-17ac-11eb-9de8-d0b8e88c6d16.png)

## references
n/a
