### PR TITLE
Added a credential in Jenkins for jobs to use

### DIFF
--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -87,6 +87,11 @@ releases:
                               id: gitlab_token
                               apiToken: "{{$gitlabApiToken}}"
                               description: "Gitlab Token"
+                          - usernamePassword:
+                              scope: GLOBAL
+                              id: gitlab_credentials
+                              username: root
+                              password: "{{$gitlabApiToken}}"
               gitlab: |
                 unclassified:
                   gitlabconnectionconfig:


### PR DESCRIPTION
## what
* Adding a credential in Jenkins at Global scope for jobs to use

## why
* Jobs need a credential to read repositories in Gitlab
* The credential needs to be Global scope or the job cannot find it
