### PR TITLE
Updated git plugin version

### DIFF
--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -56,7 +56,7 @@ releases:
             - pipeline-stage-view:2.19
             - credentials-binding:1.24
             - font-awesome-api:5.15.1-1
-            - git:4.5.0
+            - git:4.5.1
             - gitlab-oauth:1.10
             - gitlab-plugin:1.5.13
             - matrix-auth:2.6.4


### PR DESCRIPTION
## what
* Updated git plugin in Jenkins to 4.5.1

## why
* The gitlab-oauth plugin requires 4.5.1
* The gitlab-oauth plugin began failing to install, even though gitlab-oauth plugin version was unchanged