### PR TITLE
Feature/disable signup

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 terraform 0.13.5
 terraform-docs v0.10.1
 tflint 0.20.3
-tfsec 0.36.0
+tfsec 0.36.6
 helmfile 0.132.1
 helm 3.4.0

--- a/helmfiles/subhelmfiles/gitlab.helmfile.yaml
+++ b/helmfiles/subhelmfiles/gitlab.helmfile.yaml
@@ -63,6 +63,8 @@ releases:
             enableImpersonation: true
             defaultCanCreateGroup: false
             usernameChangingEnabled: false
+            initialDefaults:
+              signupEnabled: false
             defaultProjectsFeatures:
               issues: true
               mergeRequests: true


### PR DESCRIPTION
## what
* For the EVTR module to fit our needs, we want to utilize the users generated by our CaC rather than click-ops signup users.

## why
* To restrict EVTR to utilize users generated by CaC rather than allowing for signup

## references
* N/A
