### PR TITLE
Updated CaC plugin version

### DIFF
--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -57,7 +57,7 @@ releases:
             - gitlab-oauth:1.10
             - gitlab-plugin:1.5.13
             - matrix-auth:2.6.4
-            - configuration-as-code:1.46
+            - configuration-as-code:1.47
             - blueocean:1.24.3
           additionalPlugins:
             - antisamy-markup-formatter:2.1


### PR DESCRIPTION
## what
* Update version of Configuration as Code plugin for Jenkins

## why
* Credentials plugin is a dependency of the Credentials-binding plugin
* Credentials plugin's latest release requires the latest version of Configuration as Code
* Without the latest version, there is a cascade effect of plugins failing to load
