### PR TITLE
Update plugin versions for Kubernetes Plugin

### DIFF
--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -48,7 +48,7 @@ releases:
           jenkinsUrl: "https://{{$jenkinsHostName}}"
           jenkinsAdminEmail: {{$jenkinsAdminEmail | quote}}
           installPlugins:
-            - kubernetes:1.27.7
+            - kubernetes:1.30.0
             - workflow-job:2.40
             - workflow-aggregator:2.6
             - workflow-cps-global-lib:2.18
@@ -106,7 +106,7 @@ releases:
             - handlebars:3.0.8
             - handy-uri-templates-2-api:2.1.8-1.0
             - htmlpublisher:1.25
-            - jackson2-api:2.12.2
+            - jackson2-api:2.12.3
             - jdk-tool:1.0
             - jenkins-design-language:1.24.6
             - jira:3.2.1
@@ -114,7 +114,7 @@ releases:
             - jquery3-api:3.6.0-1
             - jsch:0.1.55.2
             - junit:1.49
-            - kubernetes-client-api:4.13.2-1
+            - kubernetes-client-api:5.4.1
             - kubernetes-credentials:0.8.0
             - lockable-resources:2.10
             - mailer:1.34

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -115,7 +115,7 @@ releases:
             - jsch:0.1.55.2
             - junit:1.49
             - kubernetes-client-api:5.4.1
-            - kubernetes-credentials:0.8.0
+            - kubernetes-credentials:0.9.0
             - lockable-resources:2.10
             - mailer:1.34
             - matrix-project:1.18

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -91,7 +91,7 @@ releases:
             - cloudbees-bitbucket-branch-source:2.9.7
             - cloudbees-folder:6.15
             - command-launcher:1.2
-            - credentials:2.3.17
+            - credentials:2.5.0
             - display-url-api:2.3.4
             - durable-task:1.35
             - echarts-api:5.0.2-1

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -144,7 +144,7 @@ releases:
             - token-macro:2.13
             - trilead-api:1.0.13
             - variant:1.4
-            - workflow-api:2.42
+            - workflow-api:2.45
             - workflow-basic-steps:2.22
             - workflow-cps:2.90
             - workflow-durable-task-step:2.38

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -93,7 +93,7 @@ releases:
             - command-launcher:1.2
             - credentials:2.5.0
             - display-url-api:2.3.4
-            - durable-task:1.35
+            - durable-task:1.37
             - echarts-api:5.0.2-1
             - favorite:2.3.2
             - font-awesome-api:5.15.2-2

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -140,7 +140,7 @@ releases:
             - snakeyaml-api:1.27.0
             - sse-gateway:1.24
             - ssh-credentials:1.18.1
-            - structs:1.22
+            - structs:1.23
             - token-macro:2.13
             - trilead-api:1.0.13
             - variant:1.4


### PR DESCRIPTION
## what
* Update Kubernetes to `1.30.0` from `1.27.7`
* Update workflow-api version to `2.45` from `2.42`
* Update credentials version to `2.5.0` from `2.3.17`
* Update durable-task to `1.37` from `1.35`
* Update jackson2-api to `2.12.3` from `2.12.2`
* Update kubernetes-client-api to `5.4.1` from `4.13.2-1`
* Update kubernetes-credentials to `0.9.0` from `0.8.0`
* Update structs to `1.23` from `1.22`

## why
* Kubernetes 1.30.0 depends on the newer versions of plugins

