### PR TITLE
Update Jenkins Chart

### DIFF
--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -221,7 +221,7 @@ releases:
               cert-manager.io/cluster-issuer: {{$clusterIssuer | quote}}
               kubernetes.io/ingress.class: "nginx"
               kubernetes.io/ingress.provider: "nginx"
-              ingressClassName: "nginx"
+            ingressClassName: "nginx"
             hostName: {{$jenkinsHostName | quote}}
             tls:
               - secretName: "tls-{{$jenkinsHostName}}"

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -221,6 +221,7 @@ releases:
               cert-manager.io/cluster-issuer: {{$clusterIssuer | quote}}
               kubernetes.io/ingress.class: "nginx"
               kubernetes.io/ingress.provider: "nginx"
+              ingressClassName: "nginx"
             hostName: {{$jenkinsHostName | quote}}
             tls:
               - secretName: "tls-{{$jenkinsHostName}}"

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -24,15 +24,15 @@ releases:
       namespace: "jenkins"
       vendor: "jenkins"
     chart: "jenkins/jenkins"
-    version: "2.17.1"
+    version: "3.3.23"
     wait: true
     atomic: true
     cleanupOnFail: true
     timeout: 1200
     values:
-      - master:
+      - controller:
           image: "jenkins/jenkins"
-          tag: "2.249.3-lts-centos7"
+          tag: "2.289.1-jdk11"
           imagePullPolicy: "IfNotPresent"
           admin:
             existingSecret: {{$initialAdminCredsSecretName | quote}}
@@ -46,7 +46,6 @@ releases:
               cpu: "2"
               memory: "4Gi"
           jenkinsUrl: "https://{{$jenkinsHostName}}"
-          jenkinsAdminEmail: {{$jenkinsAdminEmail | quote}}
           installPlugins:
             - kubernetes:1.27.7
             - workflow-job:2.40
@@ -91,7 +90,7 @@ releases:
             - cloudbees-bitbucket-branch-source:2.9.7
             - cloudbees-folder:6.15
             - command-launcher:1.2
-            - credentials:2.3.17
+            - credentials:2.5.0
             - display-url-api:2.3.4
             - durable-task:1.35
             - echarts-api:5.0.2-1
@@ -152,6 +151,7 @@ releases:
             - workflow-scm-step:2.12
             - workflow-step-api:2.23
             - workflow-support:3.8
+          installLatestPlugins: false
           initializeOnce: true
           overwritePlugins: true
           enableRawHtmlMarkupFormatter: true
@@ -160,7 +160,6 @@ releases:
 #            - "new java.lang.String byte[]"
 #            - "staticMethod java.util.Base64 getDecoder"
           JCasC:
-            enabled: true
             defaultConfig: true
             configScripts:
               welcome-message: |
@@ -227,7 +226,10 @@ releases:
               - secretName: "tls-{{$jenkinsHostName}}"
                 hosts:
                   - {{$jenkinsHostName | quote}}
-          healthProbeLivenessInitialDelay: 180
+          healthProbes: true
+          probes:
+            livenessProbe:
+              initialDelaySeconds: 180
         persistence:
           enabled: true
           storageClass: efs

--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -90,7 +90,7 @@ releases:
             - cloudbees-bitbucket-branch-source:2.9.7
             - cloudbees-folder:6.15
             - command-launcher:1.2
-            - credentials:2.5.0
+            - credentials:2.3.17
             - display-url-api:2.3.4
             - durable-task:1.35
             - echarts-api:5.0.2-1


### PR DESCRIPTION
## what
* Updating Jenkins chart version to 3.3.23 from 2.17.0
* Changed template keys in the helmfile values file to accommodate the updated chart values

## why
* The plugin manager that Jenkins used in the previous version tried downloading latest versions of dependencies
* This caused errors when we had pinned versions that were older
* The update that fixes this bug was not applied to a 2.x.x version of the Jenkins chart, as 2.17.0 is the newest 2.x.x


