### PR TITLE
Remove ingressClassName to use annotation instead

### DIFF
--- a/helmfiles/subhelmfiles/jenkins.helmfile.yaml
+++ b/helmfiles/subhelmfiles/jenkins.helmfile.yaml
@@ -221,7 +221,6 @@ releases:
               cert-manager.io/cluster-issuer: {{$clusterIssuer | quote}}
               kubernetes.io/ingress.class: "nginx"
               kubernetes.io/ingress.provider: "nginx"
-            ingressClassName: "nginx"
             hostName: {{$jenkinsHostName | quote}}
             tls:
               - secretName: "tls-{{$jenkinsHostName}}"


### PR DESCRIPTION
## what
* Remove ingressClassName in favor of using the annotation

## why
* The annotation and class name cannot both be used, or the installation will fail on a fresh deployment
